### PR TITLE
fix: resolve SSE streaming issues for FTP Sync and Summarize Meeting

### DIFF
--- a/backend/src/analyzer/api/meeting.py
+++ b/backend/src/analyzer/api/meeting.py
@@ -182,29 +182,30 @@ async def summarize_meeting_stream(
                 force=force,
             ):
                 if event.type == "progress":
-                    # Map backend progress format to frontend expected format
-                    progress_data = {
-                        "event": "progress",
-                        "current": event.progress.get("processed", 0),
-                        "total": event.progress.get("total_documents", 0),
-                        "contribution_number": event.progress.get("current_document", ""),
-                    }
                     yield {
                         "event": "progress",
-                        "data": json.dumps(progress_data),
+                        "data": json.dumps(
+                            {
+                                "current": event.progress.get("processed", 0),
+                                "total": event.progress.get("total_documents", 0),
+                                "contribution_number": event.progress.get("current_document", ""),
+                            }
+                        ),
                     }
                 elif event.type == "document_summary":
-                    # Send progress event for document_summary
+                    # Also send a progress event for document_summary
                     if event.progress:
-                        progress_data = {
-                            "event": "progress",
-                            "current": event.progress.get("processed", 0),
-                            "total": event.progress.get("total_documents", 0),
-                            "contribution_number": event.progress.get("current_document", ""),
-                        }
                         yield {
                             "event": "progress",
-                            "data": json.dumps(progress_data),
+                            "data": json.dumps(
+                                {
+                                    "current": event.progress.get("processed", 0),
+                                    "total": event.progress.get("total_documents", 0),
+                                    "contribution_number": event.progress.get(
+                                        "current_document", ""
+                                    ),
+                                }
+                            ),
                         }
                     yield {
                         "event": "document_summary",
@@ -232,13 +233,11 @@ async def summarize_meeting_stream(
                         ),
                     }
                 elif event.type == "done":
-                    # Send complete event with full summary for frontend compatibility
                     summary_response = meeting_summary_to_response(event.result)
                     yield {
                         "event": "complete",
                         "data": json.dumps(
                             {
-                                "event": "complete",
                                 "summary": summary_response.model_dump(),
                             }
                         ),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -220,6 +220,7 @@ class FetchEventSource {
   private eventListeners: Map<string, ((event: MessageEvent) => void)[]> = new Map();
   public readyState: number = 0; // 0=CONNECTING, 1=OPEN, 2=CLOSED
   public onopen: (() => void) | null = null;
+  public onmessage: ((event: MessageEvent) => void) | null = null;
   public onerror: ((error: Event) => void) | null = null;
 
   constructor(
@@ -301,6 +302,10 @@ class FetchEventSource {
     const listeners = this.eventListeners.get(type) || [];
     for (const listener of listeners) {
       listener(event);
+    }
+    // Fallback to onmessage for unnamed "message" events (EventSource API compat)
+    if (type === "message" && listeners.length === 0) {
+      this.onmessage?.(event);
     }
   }
 


### PR DESCRIPTION
## Summary

- **FTP Sync**: Backend used `StreamingResponse` with unnamed events, but `FetchEventSource` didn't support `onmessage`. Switched to `EventSourceResponse` with named events (`progress`, `complete`, `error`) and `addEventListener()` pattern on frontend.
- **Summarize Meeting**: Frontend checked `data.event` field inside the JSON payload instead of using `event.type` (the SSE event name). Refactored to per-event `addEventListener()` handlers, matching the working batch process pattern.
- **FetchEventSource**: Added `onmessage` callback support for `EventSource` API compatibility.

## Root Cause

| Feature | Backend Issue | Frontend Issue |
|---------|--------------|----------------|
| FTP Sync | Used `StreamingResponse` (raw `data:` only, no `event:` header) | Used `onmessage` which `FetchEventSource` didn't implement |
| Summarize Meeting | Included redundant `"event"` field in data payload | Checked `data.event` instead of `event.type` for routing |
| Process All Docs | _(none - working correctly)_ | _(none - working correctly)_ |

## Test plan

- [ ] FTP Sync: Click "Sync This Directory" / "Re-sync" and verify real-time progress updates appear
- [ ] Summarize Meeting: Click "Summarize Meeting" and verify progress bar updates and summary appears on completion
- [ ] Process All Documents: Verify existing batch processing still works (regression check)
- [ ] Check browser console for `[SSE]` log entries confirming events are received

🤖 Generated with [Claude Code](https://claude.com/claude-code)