### PR TITLE
fix: add error handling for JSON.parse in SSE event handlers

### DIFF
--- a/frontend/src/app/meetings/[id]/page.tsx
+++ b/frontend/src/app/meetings/[id]/page.tsx
@@ -144,12 +144,14 @@ export default function MeetingDetailPage() {
           console.log("[SSE] Complete received");
           setCurrentSummary(data.summary);
           setLatestSummary(data.summary);
-          setSummaryProgress(null);
-          setIsSummarizing(false);
           toast.success("Meeting summary completed");
-          eventSource.close();
         } catch (e) {
           console.error("Failed to parse SSE complete data:", e, event.data);
+          toast.error("Failed to process summary completion");
+        } finally {
+          setSummaryProgress(null);
+          setIsSummarizing(false);
+          eventSource.close();
         }
       });
 

--- a/frontend/src/components/sync/FTPBrowser.tsx
+++ b/frontend/src/components/sync/FTPBrowser.tsx
@@ -61,16 +61,25 @@ export function FTPBrowser() {
       const eventSource = await createFTPSyncStream(sync_id);
 
       const handleSyncEvent = (event: MessageEvent) => {
-        const data = JSON.parse(event.data) as FTPSyncProgress;
-        setSyncProgress(data);
+        try {
+          const data = JSON.parse(event.data) as FTPSyncProgress;
+          setSyncProgress(data);
+        } catch (e) {
+          console.error("Failed to parse FTP sync progress:", e, event.data);
+        }
       };
 
       const handleTerminalEvent = (event: MessageEvent) => {
-        const data = JSON.parse(event.data) as FTPSyncProgress;
-        setSyncProgress(data);
-        eventSource.close();
-        loadDirectory(currentPath);
-        setRefreshTrigger((prev) => prev + 1);
+        try {
+          const data = JSON.parse(event.data) as FTPSyncProgress;
+          setSyncProgress(data);
+        } catch (e) {
+          console.error("Failed to parse FTP sync terminal event:", e, event.data);
+        } finally {
+          eventSource.close();
+          loadDirectory(currentPath);
+          setRefreshTrigger((prev) => prev + 1);
+        }
       };
 
       eventSource.addEventListener("progress", handleSyncEvent);


### PR DESCRIPTION
## Summary
- **meetings/[id]/page.tsx**: `complete` イベントハンドラのクリーンアップ処理（`setSummaryProgress(null)`, `setIsSummarizing(false)`, `eventSource.close()`）を `try` ブロックから `finally` ブロックに移動。`JSON.parse` 失敗時もUI状態が確実にリセットされるように修正
- **FTPBrowser.tsx**: `handleSyncEvent` と `handleTerminalEvent` に try/catch を追加。`handleTerminalEvent` では `finally` ブロックでクリーンアップを実行し、パース失敗時も `eventSource.close()` / `loadDirectory` / `setRefreshTrigger` が保証されるように修正

Addresses review comments from PR #15.

## Test plan
- [ ] FTP Sync のSSEストリーミングが正常に動作することを確認
- [ ] Summarize Meeting のSSEストリーミングが正常に動作することを確認
- [ ] 不正なSSEデータ受信時にUIがスタック状態にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)