### PR TITLE
fix: use latin-1 encoding for FTP to handle non-UTF-8 directory listings

### DIFF
--- a/backend/src/analyzer/services/ftp_sync.py
+++ b/backend/src/analyzer/services/ftp_sync.py
@@ -109,7 +109,7 @@ class FTPSyncService:
 
     def _connect(self, timeout: int = 60) -> FTP:
         """Establish FTP connection."""
-        ftp = FTP(self.host, timeout=timeout)
+        ftp = FTP(self.host, timeout=timeout, encoding="latin-1")
         ftp.login(self.user, self.password)
 
         # Patch makepasv to handle EPSV responses from servers like 3gpp.org


### PR DESCRIPTION
## Summary

- `/Meetings_3GPP_SYNC/SA2` のFTP同期で `'utf-8' codec can't decode byte 0xa0` エラーが発生
- Python `ftplib.FTP` のデフォルトUTF-8エンコーディングを `latin-1` に変更
- `_connect()` メソッドの1行変更のみ。Latin-1は全バイト値(0x00-0xFF)をデコード可能で、ASCII文字列には影響なし

## Test plan

- [x] `uv run pytest` 全20テストパス
- [x] `npm run build` フロントエンドビルド成功
- [x] `uv run ruff check src/` リントパス
- [ ] Cloud Runデプロイ後、`/Meetings_3GPP_SYNC/SA2` の同期を再テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)