### PR TITLE
Fix: cascade meeting_id update to chunks on re-sync

### DIFF
--- a/backend/src/analyzer/services/ftp_sync.py
+++ b/backend/src/analyzer/services/ftp_sync.py
@@ -601,6 +601,15 @@ class FTPSyncService:
                         if meeting:
                             update_data["meeting"] = meeting.model_dump(mode="json")
                         await self.firestore.update_document(doc_id, update_data)
+                        # Cascade meeting_id change to chunks for RAG search
+                        if meeting_changed and meeting:
+                            chunks_updated = await self.firestore.update_chunks_meeting_id(
+                                doc_id, meeting.id
+                            )
+                            if chunks_updated > 0:
+                                logger.info(
+                                    f"Updated {chunks_updated} chunks meeting_id for {doc_id}"
+                                )
                         result["documents_updated"] += 1
                 else:
                     # Create new document - no existing GCS paths to preserve


### PR DESCRIPTION
## Summary

FTP再同期でドキュメントのmeetingが変更された際、チャンクの`metadata.meeting_id`も連動更新するように修正。

## Problem

RAGベクトル検索は`metadata.meeting_id`でフィルタしているが、ドキュメントのmeeting変更時にチャンクのmeeting_idが古いまま残る。

例: ドキュメントが `TSGS1#113#Goa` → `SA1` に移動
- ドキュメントの`meeting.id`: `SA1` に更新済み
- チャンクの`metadata.meeting_id`: `TSGS1#113#Goa` のまま
- → `SA1`スコープのRAG検索で107件のチャンクがヒットしない

## Changes

**`backend/src/analyzer/providers/firestore_client.py`**
- `update_chunks_meeting_id()` メソッド追加
- `delete_chunks_by_document()` と同じバッチパターン (500件/batch)

**`backend/src/analyzer/services/ftp_sync.py`**
- `sync_directory()` で `meeting_changed` 検出時にchunksのmeeting_idも更新

## Test plan

- [x] ruff check/format pass
- [x] Frontend lint pass
- [x] All backend tests pass (20/20)
- [x] Frontend build succeeds
- [ ] Re-sync meeting and verify chunks' metadata.meeting_id is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)