### PR TITLE
fix: use server-side pre-filtering for vector search

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -158,6 +158,22 @@
         { "fieldPath": "scope", "order": "ASCENDING" },
         { "fieldPath": "created_at", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "chunks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "metadata.meeting_id", "order": "ASCENDING" },
+        { "fieldPath": "embedding", "vectorConfig": { "dimension": 768, "flat": {} } }
+      ]
+    },
+    {
+      "collectionGroup": "chunks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "metadata.document_id", "order": "ASCENDING" },
+        { "fieldPath": "embedding", "vectorConfig": { "dimension": 768, "flat": {} } }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary

- 会合指定のQ&AでRAG検索がヒットしない問題を修正
- `vector_search()` のメタデータフィルタ（`meeting_id`等）がクライアントサイド（取得後）に適用されていたのが根本原因
- `find_nearest()` が全チャンクからグローバルtop K件を取得→その後フィルタリングするため、上位K件に対象会合のチャンクが無い場合に結果0件になっていた
- `.where()` を `find_nearest()` の前にチェーンしてサーバーサイドプリフィルタを適用するよう修正
- 複合ベクトルインデックス（`metadata.meeting_id` + `embedding`, `metadata.document_id` + `embedding`）を追加

## Note

デプロイ後、`firebase deploy --only firestore:indexes` でインデックスをデプロイする必要があります。インデックスのビルドに数分〜数十分かかる場合があります。

## Test plan

- [x] ruff check / ruff format 通過
- [x] pytest 20/20 通過
- [x] frontend build 成功
- [x] frontend lint 通過
- [ ] デプロイ後、会合指定Q&Aで結果が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)