### PR TITLE
fix: use signInWithRedirect for Google sign-in

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { getRedirectResult } from "firebase/auth";
+import { getFirebaseAuth } from "@/lib/firebase";
 import { useAuth } from "@/lib/auth/AuthContext";
 
 export default function LoginPage() {
@@ -9,6 +11,15 @@ export default function LoginPage() {
   const [isSigningIn, setIsSigningIn] = useState(false);
   const { user, loading, signInWithGoogle } = useAuth();
   const router = useRouter();
+
+  // Check for redirect result errors after returning from Google sign-in
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    getRedirectResult(auth).catch((err) => {
+      console.error("Redirect sign in error:", err);
+      setError("Failed to sign in with Google. Please try again.");
+    });
+  }, []);
 
   useEffect(() => {
     if (!loading && user) {
@@ -21,11 +32,10 @@ export default function LoginPage() {
     setIsSigningIn(true);
     try {
       await signInWithGoogle();
-      router.push("/");
+      // Page will redirect to Google; execution won't continue past here
     } catch (err) {
       console.error("Sign in error:", err);
       setError("Failed to sign in with Google. Please try again.");
-    } finally {
       setIsSigningIn(false);
     }
   };

--- a/frontend/src/lib/auth/AuthContext.tsx
+++ b/frontend/src/lib/auth/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import {
   type User,
-  signInWithPopup,
+  signInWithRedirect,
   GoogleAuthProvider,
   signOut as firebaseSignOut,
   onAuthStateChanged,
@@ -68,7 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signInWithGoogle = async () => {
     const auth = getFirebaseAuth();
-    await signInWithPopup(auth, googleProvider);
+    await signInWithRedirect(auth, googleProvider);
   };
 
   const signOut = async () => {


### PR DESCRIPTION
## Summary
- `signInWithPopup` → `signInWithRedirect` に変更し、シークレットウィンドウおよびモバイルブラウザ(Android Chrome)でGoogle ログインが失敗する問題を修正
- `signInWithPopup` はサードパーティ Cookie に依存しており、シークレットウィンドウやモバイルブラウザではブロックされるため失敗していた
- リダイレクト後のエラーハンドリングを `getRedirectResult` で追加

## Test plan
- [ ] 通常ウィンドウで Google ログインが動作すること
- [ ] シークレットウィンドウで Google ログインが動作すること
- [ ] モバイルブラウザ (Android Chrome) で Google ログインが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)