### PR TITLE
fix: proxy Firebase Auth handler to fix cross-origin sign-in failure

### DIFF
--- a/frontend/apphosting.yaml
+++ b/frontend/apphosting.yaml
@@ -13,3 +13,7 @@ env:
     availability:
       - BUILD
       - RUNTIME
+  - variable: FIREBASE_AUTH_PROXY_DOMAIN
+    secret: firebase-auth-proxy-domain  # e.g. <project-id>.firebaseapp.com
+    availability:
+      - BUILD

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -67,6 +67,16 @@ const nextConfig: NextConfig = {
         source: "/api/:path*",
         destination: `${apiUrl}/:path*`,
       },
+      // Proxy Firebase Auth handler so the auth flow stays first-party.
+      // This avoids cross-origin / third-party cookie issues with signInWithRedirect.
+      ...(process.env.FIREBASE_AUTH_PROXY_DOMAIN
+        ? [
+            {
+              source: "/__/auth/:path*",
+              destination: `https://${process.env.FIREBASE_AUTH_PROXY_DOMAIN}/__/auth/:path*`,
+            },
+          ]
+        : []),
     ];
   },
 };

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -25,6 +25,11 @@ function getFirebaseApp(): FirebaseApp {
 function getFirebaseAuth(): Auth {
   if (!auth) {
     auth = getAuth(getFirebaseApp());
+    // Use app's own domain as authDomain so the auth flow is first-party.
+    // This works with the /__/auth/* rewrite in next.config.ts.
+    if (typeof window !== "undefined") {
+      auth.config.authDomain = window.location.host;
+    }
   }
   return auth;
 }


### PR DESCRIPTION
## Summary
- Firebase App Hosting のドメインと `authDomain` の不一致により `signInWithRedirect` がクロスオリジンエラーで失敗する問題を修正
- Next.js の rewrite で `/__/auth/*` を Firebase Auth Handler にプロキシし、認証フローをファーストパーティ化
- `authDomain` を `window.location.host` に上書きすることで、プロキシ経由の認証フローを実現

## Changes
- `frontend/next.config.ts`: `/__/auth/:path*` → `FIREBASE_AUTH_PROXY_DOMAIN` への rewrite 追加
- `frontend/src/lib/firebase.ts`: `authDomain` を `window.location.host` に上書き
- `frontend/apphosting.yaml`: `FIREBASE_AUTH_PROXY_DOMAIN` シークレット定義追加
- `docs/deployment.md`: セットアップ手順を追記

## Test plan
- [ ] ローカル開発環境で Google サインインが動作すること（`FIREBASE_AUTH_PROXY_DOMAIN` 未設定時に rewrite が追加されないこと）
- [ ] App Hosting デプロイ後、Google サインイン（signInWithRedirect）が成功すること
- [ ] シークレットブラウジング / モバイルブラウザでもサインインが成功すること
- [ ] Firebase Console の承認済みドメインに App Hosting ドメインが登録されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)