### PR TITLE
feat: add Agentic Search mode for Q&A

### DIFF
--- a/backend/src/analyzer/agents/tools/adk_agentic_tools.py
+++ b/backend/src/analyzer/agents/tools/adk_agentic_tools.py
@@ -1,0 +1,174 @@
+"""Tools for Agentic Search mode agents."""
+
+import logging
+import uuid
+from typing import Any
+
+from google.adk.tools import ToolContext
+
+from analyzer.agents.context import AgentToolContext, get_current_agent_context
+
+logger = logging.getLogger(__name__)
+
+
+async def list_meeting_documents_enhanced(
+    meeting_id: str,
+    search_text: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    List documents in a meeting with optional title/filename keyword search.
+
+    Use this to discover what documents are available in a meeting.
+    You can search by keywords in the title or filename to find relevant contributions.
+
+    Args:
+        meeting_id: The meeting ID to list documents for.
+            Format: 'SA2#162' or 'RAN1#100'.
+        search_text: Optional keyword to search in document titles and filenames.
+            Use this to find documents about specific topics.
+            Example: 'power saving', 'handover', 'PDU session'.
+        page: Page number (1-indexed). Use for pagination when many documents exist.
+        page_size: Number of documents per page. Default: 50. Max recommended: 100.
+        tool_context: ADK tool context (injected automatically by ADK).
+
+    Returns:
+        List of documents with metadata including document_id, contribution_number,
+        title, source, filename, and document_type. Also includes pagination info.
+    """
+    ctx: AgentToolContext | None = get_current_agent_context()
+    if not ctx and tool_context and tool_context.state:
+        ctx = tool_context.state.get("agent_context")
+
+    if not ctx or not ctx.document_service:
+        return {"error": "Document service not available", "documents": [], "total": 0}
+
+    logger.info(
+        f"Listing documents for meeting: {meeting_id}, "
+        f"search_text={search_text}, page={page}, page_size={page_size}"
+    )
+
+    try:
+        documents, total = await ctx.document_service.list_documents(
+            meeting_id=meeting_id,
+            status="indexed",
+            search_text=search_text,
+            page=page,
+            page_size=page_size,
+        )
+
+        results = []
+        for doc in documents:
+            results.append(
+                {
+                    "document_id": doc.id,
+                    "contribution_number": doc.contribution_number,
+                    "title": doc.title or "Untitled",
+                    "source": doc.source or "Unknown",
+                    "filename": doc.source_file.filename if doc.source_file else "",
+                    "document_type": doc.document_type.value if doc.document_type else "unknown",
+                }
+            )
+
+        return {
+            "meeting_id": meeting_id,
+            "documents": results,
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "returned": len(results),
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing documents for meeting {meeting_id}: {e}")
+        return {"error": str(e), "documents": [], "total": 0}
+
+
+async def investigate_document(
+    document_id: str,
+    investigation_query: str,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Deeply investigate a specific document to answer a question.
+
+    This tool delegates to a sub-agent that reads the document content
+    and analyzes it in context of the investigation query. Use this when
+    you need detailed understanding of a specific document.
+
+    This is more thorough than get_document_summary but takes longer.
+    Use it for documents you've identified as particularly relevant.
+
+    Args:
+        document_id: The document ID to investigate.
+        investigation_query: What to look for in this document.
+            Be specific about what information you need.
+            Example: 'What changes does this document propose to DRX parameters?'
+        tool_context: ADK tool context (injected automatically by ADK).
+
+    Returns:
+        Analysis of the document focused on the investigation query,
+        including the contribution number and evidence count.
+    """
+    from analyzer.agents.adk_agents import ADKAgentRunner, create_document_investigation_agent
+
+    ctx: AgentToolContext | None = get_current_agent_context()
+    if not ctx and tool_context and tool_context.state:
+        ctx = tool_context.state.get("agent_context")
+
+    if not ctx:
+        return {"error": "Agent context not initialized"}
+
+    logger.info(f"Investigating document {document_id}: query='{investigation_query[:50]}...'")
+
+    try:
+        # Get document metadata for context
+        doc_data = None
+        contribution_number = None
+        if ctx.firestore:
+            doc_data = await ctx.firestore.get_document(document_id)
+            if doc_data:
+                contribution_number = doc_data.get("contribution_number")
+
+        if not doc_data:
+            return {"error": f"Document not found: {document_id}"}
+
+        # Create a sub-agent for document investigation
+        sub_agent = create_document_investigation_agent(
+            document_id=document_id,
+            contribution_number=contribution_number,
+            language=ctx.language,
+        )
+
+        # Create a separate context for the sub-agent
+        sub_context = AgentToolContext(
+            evidence_provider=ctx.evidence_provider,
+            scope="document",
+            scope_id=document_id,
+            language=ctx.language,
+            filters={"document_id": document_id},
+        )
+
+        # Run the sub-agent
+        runner = ADKAgentRunner(agent=sub_agent, agent_context=sub_context)
+        analysis_text, evidences = await runner.run(
+            user_input=investigation_query,
+            user_id="investigation_sub_agent",
+            session_id=str(uuid.uuid4()),
+        )
+
+        # Track evidences from sub-agent in the main context
+        ctx.used_evidences.extend(evidences)
+
+        return {
+            "document_id": document_id,
+            "contribution_number": contribution_number,
+            "analysis": analysis_text,
+            "evidence_count": len(evidences),
+        }
+
+    except Exception as e:
+        logger.error(f"Error investigating document {document_id}: {e}")
+        return {"error": str(e)}

--- a/backend/src/analyzer/dependencies.py
+++ b/backend/src/analyzer/dependencies.py
@@ -177,6 +177,7 @@ def get_report_prompt_service(
 def get_qa_service(
     evidence_provider: Annotated[EvidenceProvider, Depends(get_evidence_provider)],
     firestore: Annotated[FirestoreClient, Depends(get_firestore_client)],
+    document_service: Annotated[DocumentService, Depends(get_document_service)],
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> QAService:
     """Get QAService instance."""
@@ -186,6 +187,7 @@ def get_qa_service(
         project_id=settings.gcp_project_id,
         location=settings.vertex_ai_location,
         model=settings.qa_model,
+        document_service=document_service,
     )
 
 

--- a/backend/src/analyzer/models/qa.py
+++ b/backend/src/analyzer/models/qa.py
@@ -9,6 +9,13 @@ from pydantic import BaseModel, Field
 from analyzer.models.evidence import Evidence
 
 
+class QAMode(str, Enum):
+    """Mode for Q&A processing."""
+
+    RAG = "rag"  # Traditional RAG-only search
+    AGENTIC = "agentic"  # Agentic search with planning and multi-tool exploration
+
+
 class QAScope(str, Enum):
     """Scope for Q&A searches."""
 
@@ -51,6 +58,10 @@ class QARequest(BaseModel):
         default=None,
         description="Session ID for conversation continuity",
     )
+    mode: QAMode = Field(
+        default=QAMode.RAG,
+        description="Q&A mode: rag (RAG-only) or agentic (multi-tool exploration)",
+    )
 
 
 class QAResult(BaseModel):
@@ -69,6 +80,10 @@ class QAResult(BaseModel):
         default_factory=datetime.utcnow,
         description="Timestamp when the result was created",
     )
+    mode: QAMode = Field(
+        default=QAMode.RAG,
+        description="Q&A mode used for this result",
+    )
     created_by: str | None = Field(
         default=None,
         description="User ID who initiated the Q&A",
@@ -81,6 +96,7 @@ class QAResult(BaseModel):
             "answer": self.answer,
             "scope": self.scope.value,
             "scope_id": self.scope_id,
+            "mode": self.mode.value,
             "evidences": [ev.model_dump(mode="json") for ev in self.evidences],
             "created_at": self.created_at,
             "created_by": self.created_by,
@@ -96,6 +112,7 @@ class QAResult(BaseModel):
             answer=data.get("answer", ""),
             scope=QAScope(data.get("scope", "global")),
             scope_id=data.get("scope_id"),
+            mode=QAMode(data.get("mode", "rag")),
             evidences=evidences,
             created_at=data.get("created_at", datetime.utcnow()),
             created_by=data.get("created_by"),

--- a/docs/agentic-search.md
+++ b/docs/agentic-search.md
@@ -1,0 +1,213 @@
+# Agentic Search 設計書
+
+## 概要
+
+Q&A画面の新しいモード「Agentic Search」の設計。従来の RAG Search がベクトル検索の結果のみを基に回答するのに対し、Agentic Search ではAgent が能動的にドキュメント一覧の調査、関連寄書の特定、個別文書の深掘りなどを行い、より精度の高い調査・回答を生成する。
+
+### RAG Search vs Agentic Search
+
+| 観点 | RAG Search | Agentic Search |
+|------|-----------|----------------|
+| 検索方式 | ベクトル類似度検索（1回〜数回） | Agent が計画を立てマルチステップで探索 |
+| ツール | `search_evidence` のみ | ドキュメント一覧、メタデータ検索、RAG検索、個別文書調査 |
+| 対応スコープ | document, meeting, global | meeting のみ |
+| 適した質問 | 特定トピックの情報検索 | 会合全体の動向調査、議題横断の分析、合意結果の調査 |
+| 応答速度 | 高速 | 調査深度に応じて時間がかかる |
+| 透明性 | 最終回答のみ | 調査計画・ツール呼び出し・中間結果を逐次表示 |
+
+## アーキテクチャ
+
+### Agent構成: Single Agent + AgentTool
+
+```
+┌─────────────────────────────────────────────────┐
+│  Agentic Search Agent (Main)                    │
+│                                                 │
+│  System Instruction:                            │
+│  - クエリ分析 → 調査計画立案                       │
+│  - ドキュメント一覧から関連寄書特定                   │
+│  - ツール選択・実行判断                             │
+│  - 最終サマライズ・回答生成                          │
+│                                                 │
+│  Tools:                                         │
+│  ├── list_meeting_documents (拡張版)              │
+│  │   └─ タイトル検索・ページネーション対応            │
+│  ├── search_evidence (既存)                      │
+│  │   └─ RAGベクトル検索                            │
+│  ├── get_document_summary (既存)                  │
+│  │   └─ 事前計算済みサマリー取得                     │
+│  └── investigate_document (AgentTool)            │
+│      └── Document Investigation Agent            │
+│          ├── get_document_content                │
+│          └── search_evidence                     │
+└─────────────────────────────────────────────────┘
+```
+
+### なぜ Single Agent + AgentTool か
+
+1. **既存パターンとの一貫性**: 現在のRAG Search、Meeting Report はいずれも Single Agent パターン
+2. **コンテキスト管理**: メインAgent は計画・要約に集中し、個別文書の詳細（大量チャンク）はサブAgent に委任
+3. **AgentTool の役割**: `investigate_document` は内部でサブAgent を生成・実行し、分析結果のテキストのみを返す。メインAgent のコンテキストウィンドウを保護
+
+### ストリーミング設計
+
+```
+Frontend (SSE) ← Backend (EventSourceResponse)
+    │
+    ├── event: tool_call    {"tool": "list_meeting_documents", "args": {...}}
+    ├── event: tool_result  {"tool": "list_meeting_documents", "summary": "Found 45 documents"}
+    ├── event: tool_call    {"tool": "search_evidence", "args": {...}}
+    ├── event: tool_result  {"tool": "search_evidence", "summary": "5 relevant results"}
+    ├── event: tool_call    {"tool": "investigate_document", "args": {...}}
+    ├── event: tool_result  {"tool": "investigate_document", "summary": "Analysis complete"}
+    ├── event: chunk        {"content": "調査結果をまとめます..."}
+    ├── event: chunk        {"content": "..."}
+    ├── event: evidence     {"evidence": {...}}
+    ├── event: evidence     {"evidence": {...}}
+    └── event: done         {"result_id": "...", "answer": "..."}
+```
+
+## ツール詳細
+
+### list_meeting_documents (拡張版)
+
+既存の `adk_document_tools.py` 版はステータス `indexed` 固定だが、Agentic Search 用にフィルタリングを強化。
+
+```python
+async def list_meeting_documents(
+    meeting_id: str,
+    search_text: str | None = None,   # タイトル・ファイル名でキーワード検索
+    page: int = 1,                    # ページ番号
+    page_size: int = 50,              # 1ページあたりの件数
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+```
+
+返却値:
+```json
+{
+  "meeting_id": "SA2#162",
+  "documents": [
+    {
+      "document_id": "abc123",
+      "contribution_number": "S2-2401234",
+      "title": "Discussion on UE power saving",
+      "source": "Qualcomm",
+      "filename": "S2-2401234.docx",
+      "document_type": "contribution"
+    }
+  ],
+  "total": 120,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+### investigate_document (AgentTool)
+
+メインAgent のコンテキストを保護するため、個別文書の深掘りを別Agent に委任。
+
+```python
+async def investigate_document(
+    document_id: str,
+    investigation_query: str,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+```
+
+内部動作:
+1. `create_document_investigation_agent()` でサブAgent 生成
+2. サブAgent は `get_document_content` と `search_evidence` を使って調査
+3. サブAgent の応答テキスト（分析結果）のみを返却
+
+返却値:
+```json
+{
+  "document_id": "abc123",
+  "contribution_number": "S2-2401234",
+  "analysis": "This document proposes modifications to...",
+  "evidence_count": 5
+}
+```
+
+## Agentic Search Agent のプロンプト設計
+
+### 調査ワークフロー（指示概要）
+
+1. **クエリ分析**: ユーザーの質問を分析し、何を知りたいのか明確にする
+2. **調査計画**: どのアプローチで調査するか計画を立てる
+3. **ドキュメント探索**: `list_meeting_documents` で会合の寄書一覧を取得
+4. **関連寄書特定**: タイトル・ソースから関連しそうな寄書を特定
+5. **詳細調査**: `investigate_document` で重要な寄書を深掘り
+6. **補強検索**: `search_evidence` で漏れがないか確認
+7. **回答生成**: 調査結果をサマライズして回答
+
+### Agent が活用する情報
+
+- **ドキュメントタイトル**: 寄書の目的・内容の概要がわかる
+- **ソース（source）**: 提案元の企業・団体
+- **Contribution Number**: 寄書番号のパターン（revision は番号の末尾等で推測）
+- **RAG 検索結果**: セマンティック検索で関連チャンクを取得
+- **文書内容**: `investigate_document` で個別文書の詳細を取得
+
+### 決定ステータス（Agreed/Approved/Revised等）の推測
+
+現在のデータモデルに3GPP決定ステータスのフィールドは存在しない。Agent はタイトルやRAG検索結果から推測する:
+- タイトルに "Agreed", "Approved" 等が含まれる場合
+- 文書内容に議決結果が記載されている場合
+- Revision の場合はタイトルや Contribution Number のパターンから推測
+
+## フロントエンド設計
+
+### モード切替
+
+Settings Bar に切替ボタンを追加:
+```
+[Agentic Search] [RAG Search]
+```
+
+- Agentic Search 選択時は scope を自動的に `meeting` に制限
+- RAG Search 選択時は全スコープ（document, meeting, global）選択可
+
+### 中間ステップ表示
+
+Agentic Search の応答中、ツール呼び出しと結果を逐次表示:
+
+```
+🔍 Searching meeting documents...
+  → Found 45 documents in SA2#162
+
+🔍 Searching for "UE power saving DRX"...
+  → 5 relevant results found
+
+📄 Investigating S2-2401234...
+  → Analysis: Proposes modifications to DRX parameters...
+
+📝 Generating summary...
+  [最終回答がストリーミング表示]
+```
+
+## API 変更
+
+### QARequest に mode 追加
+
+```python
+class QAMode(str, Enum):
+    RAG = "rag"
+    AGENTIC = "agentic"
+
+class QARequest(BaseModel):
+    mode: QAMode = QAMode.RAG
+    # ... existing fields
+```
+
+### ストリーミングエンドポイント
+
+`GET /qa/stream` に `mode` パラメータ追加:
+```
+GET /qa/stream?question=...&scope=meeting&scope_id=SA2%23162&mode=agentic
+```
+
+新ストリームイベント:
+- `tool_call`: `{"tool": "tool_name", "args": {"key": "value"}}`
+- `tool_result`: `{"tool": "tool_name", "summary": "result summary"}`

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
   MultiMeetingSummarizeRequest,
   MultiMeetingSummary,
   ProcessRequest,
+  QAMode,
   QARequest,
   QAResult,
   QAScope,
@@ -578,6 +579,7 @@ export async function createQAStream(
   scopeIds?: string[],
   language: AnalysisLanguage = "ja",
   sessionId?: string,
+  mode: QAMode = "rag",
 ): Promise<EventSource> {
   const token = await getAuthToken();
   if (!token) {
@@ -588,6 +590,7 @@ export async function createQAStream(
     question,
     scope,
     language,
+    mode,
   });
 
   // Support multiple scope IDs (takes precedence over single scope_id)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -407,6 +407,7 @@ export function isSingleAnalysis(
 // ============================================================================
 
 // Q&A Types (P3-05)
+export type QAMode = "rag" | "agentic";
 export type QAScope = "document" | "meeting" | "global";
 
 export interface QARequest {
@@ -417,6 +418,7 @@ export interface QARequest {
   filters?: Record<string, unknown> | null;
   language: AnalysisLanguage;
   session_id?: string | null;
+  mode?: QAMode;
 }
 
 export interface QAEvidence {
@@ -569,6 +571,16 @@ export const qaScopeLabelsJa: Record<QAScope, string> = {
   document: "単一寄書",
   meeting: "会合内",
   global: "全体",
+};
+
+export const qaModeLabels: Record<QAMode, string> = {
+  agentic: "Agentic Search",
+  rag: "RAG Search",
+};
+
+export const qaModeDescriptions: Record<QAMode, string> = {
+  agentic: "Agent が調査計画を立て、複数ツールで能動的に探索",
+  rag: "ベクトル検索で関連チャンクを取得し回答",
 };
 
 // Batch Operation Types


### PR DESCRIPTION
## Summary
- Q&A画面に **Agentic Search モード** を追加。既存の RAG Search とトグルで切替可能
- Agentic Search は会合の文書リストから関連文書を発見し、サブエージェント（AgentToolパターン）で各文書を深掘り調査した上で、エビデンス付きで回答を生成
- 中間ステップ（ツール呼び出し・結果）をリアルタイムでストリーミング表示

### Backend
- `QAMode` enum (`rag`/`agentic`) とモデル・API・サービス層での mode 分岐
- `adk_agentic_tools.py`: `list_meeting_documents_enhanced`（テキスト検索・ページネーション）、`investigate_document`（サブエージェント起動）
- `create_agentic_search_agent` / `create_document_investigation_agent` エージェント定義
- SSE ストリーミングに `tool_call`/`tool_result` イベント追加

### Frontend
- モード切替トグル（紫=Agentic / 青=RAG）
- Agentic モード時は scope を自動で meeting に制限
- 中間調査ステップのタイムライン表示（展開/折りたたみ対応）

### Design Doc
- `docs/agentic-search.md` に設計・アーキテクチャを記載

## Test plan
- [ ] RAG Search モードが従来通り動作することを確認
- [ ] Agentic Search モードで会合を選択し質問 → 文書発見・調査・回答が生成されることを確認
- [ ] 中間ステップ（ツール呼び出し・結果）がUI上にリアルタイム表示されることを確認
- [ ] Agentic モード時に scope が meeting に固定されることを確認
- [ ] `uv run pytest` 全テストパス済み
- [ ] `npm run build` ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)