### PR TITLE
fix: improve RAG search quality with full content and real similarity scores

### DIFF
--- a/backend/src/analyzer/agents/tools/adk_search_tool.py
+++ b/backend/src/analyzer/agents/tools/adk_search_tool.py
@@ -115,7 +115,7 @@ async def search_evidence(
                 {
                     "chunk_id": ev.chunk_id,
                     "contribution_number": ev.contribution_number,
-                    "content": ev.content[:500] + "..." if len(ev.content) > 500 else ev.content,
+                    "content": ev.content,
                     "clause_number": ev.clause_number,
                     "clause_title": ev.clause_title,
                     "page_number": ev.page_number,

--- a/backend/src/analyzer/providers/firestore_client.py
+++ b/backend/src/analyzer/providers/firestore_client.py
@@ -278,6 +278,7 @@ class FirestoreClient:
             query_vector=Vector(query_embedding),
             distance_measure=DistanceMeasure.COSINE,
             limit=top_k,
+            distance_result_field="vector_distance",
         )
 
         # Execute and collect results

--- a/backend/src/analyzer/services/vectorizer.py
+++ b/backend/src/analyzer/services/vectorizer.py
@@ -24,7 +24,7 @@ class VectorizerService:
         firestore: FirestoreClient,
         project_id: str,
         location: str = "asia-northeast1",
-        model: str = "text-embedding-004",
+        model: str = "gemini-embedding-001",
         dimensions: int = 768,
         batch_size: int = 100,
     ):


### PR DESCRIPTION
## Summary

- **コンテンツ切り詰め除去**: `search_evidence` ツールの500文字切り詰めを除去。LLMエージェントがチャンク全文（~4000文字）を参照可能に。従来はチャンクの12.5%しか見えておらず、回答品質・引用精度が大幅に低下していた
- **実コサイン距離スコア**: Firestoreベクトル検索の `distance_result_field` を使用し、順位ベースの人工スコアを実コサイン類似度に置換。互換性のためフォールバックも維持
- **デフォルトモデル名修正**: `VectorizerService` のデフォルト埋め込みモデルを `text-embedding-004` → `gemini-embedding-001` に修正（configとの整合性）

## Test plan

- [x] `uv run ruff check src/` — lint pass
- [x] `uv run ruff format --check src/` — format pass
- [x] `uv run pytest` — 20 tests pass
- [x] `npm run build` (frontend) — build success
- [ ] 手動テスト: Q&Aクエリでエビデンスが切り詰められていないことを確認
- [ ] 手動テスト: 関連度スコアが実コサイン類似度に基づいて変動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)