### PR TITLE
feat: enhance investigation steps with query details and enable copy button

### DIFF
--- a/frontend/src/app/qa/page.tsx
+++ b/frontend/src/app/qa/page.tsx
@@ -53,13 +53,21 @@ function ToolStepItem({ step }: { step: ToolStep }) {
   const isCall = step.type === "tool_call";
 
   let callDetail = "";
-  if (isCall && step.tool === "investigate_document" && step.args) {
-    const cn = step.args.contribution_number;
-    const title = step.args.document_title;
-    if (cn && title) {
-      callDetail = `${cn}: ${title}`;
-    } else if (cn) {
-      callDetail = cn;
+  if (isCall && step.args) {
+    if (step.tool === "investigate_document") {
+      const cn = step.args.contribution_number;
+      const title = step.args.document_title;
+      if (cn && title) {
+        callDetail = `${cn}: ${title}`;
+      } else if (cn) {
+        callDetail = cn;
+      }
+    } else if (step.tool === "search_evidence") {
+      if (step.args.query) callDetail = `"${step.args.query}"`;
+    } else if (step.tool === "list_meeting_documents_enhanced") {
+      if (step.args.search_text) callDetail = `"${step.args.search_text}"`;
+    } else if (step.tool === "get_document_summary") {
+      if (step.args.document_id) callDetail = step.args.document_id;
     }
   }
 
@@ -716,7 +724,7 @@ export default function QAPage() {
                     )}
                   </>
                 ) : (
-                  <MarkdownRenderer content={message.content} showCopyButton={false} />
+                  <MarkdownRenderer content={message.content} showCopyButton={true} />
                 )}
 
                 {/* Evidences */}


### PR DESCRIPTION
## Summary
- Q&A (Agentic Search) の Investigation steps に詳細情報を追加し、エージェントの調査過程を可視化
- 回答のマークダウンをコピーできるボタンを有効化（既存の `MarkdownRenderer` を再利用）

### Investigation steps の改善
| ツール | Before | After |
|--------|--------|-------|
| `search_evidence` | Searching | Searching - "UE power saving requirements" |
| `list_meeting_documents_enhanced` | Listing documents | Listing documents - "power saving" |
| `get_document_summary` | Reading summary | Reading summary - S2-2401234 |

### コピーボタン
- `MarkdownRenderer` の `showCopyButton` を `true` に変更するだけで有効化
- 生のマークダウンテキストがクリップボードにコピーされる

### 備考: top_k（検索件数制限）
- ツールの docstring に `Increase for broader searches, decrease for focused queries.` と既に記載済み
- エージェントは必要に応じて top_k を変更可能な設計のため、追加変更不要

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] Agentic モードで質問し、Searching ステップに検索クエリが表示されること
- [ ] Listing documents でキーワード指定時にキーワードが表示されること
- [ ] Reading summary で文書IDが表示されること
- [ ] 回答完了後にコピーボタンが表示され、マークダウンがコピーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)