### PR TITLE
refactor: migrate investigate_document to ADK AgentTool pattern

### DIFF
--- a/backend/src/analyzer/agents/guardrails.py
+++ b/backend/src/analyzer/agents/guardrails.py
@@ -18,7 +18,7 @@ from google.genai.types import Content, Part
 logger = logging.getLogger(__name__)
 
 # State key used to track LLM call count within a session
-_LLM_CALL_COUNT_KEY = "_llm_call_count"
+_LLM_CALL_COUNT_KEY = "_adk_llm_call_count"
 
 
 def create_iteration_limit_callback(


### PR DESCRIPTION
## Summary

- `investigate_document` の手動 Runner/Session 管理を ADK 組み込みの `AgentTool` クラスに移行
- `_llm_call_count` ステートキーを `_adk_llm_call_count` にリネームし、AgentTool 経由での親→子ステート漏洩を防止
- sub-agent を `InvestigationInput` Pydantic スキーマ + `AgentTool(skip_summarization=True)` でラップし、約110行の手動オーケストレーションコードを削除

## Motivation

従来の `investigate_document` は ADK の推奨パターンを使わず、ツール関数内で手動で `ADKAgentRunner` を作成し sub-agent を実行していた。ADK には `AgentTool` という組み込みの仕組みがあり、これに移行することで:

- フレームワークとの整合性が向上（Session/Runner のライフサイクル管理を ADK に委譲）
- Evidence 追跡が contextvar の自然伝播により簡潔に（手動マージ不要）
- ネットで **72行削減** (+65/-137)

## Key Changes

| File | Change |
|---|---|
| `guardrails.py` | `_llm_call_count` → `_adk_llm_call_count` (AgentTool ステートフィルタ対応) |
| `adk_agents.py` | `InvestigationInput` スキーマ追加、`create_document_investigation_agent` 汎用化、`AgentTool` ラップ |
| `adk_agentic_tools.py` | `investigate_document` 関数削除、不要 import 削除 |
| Frontend | **変更なし** (`name="investigate_document"` + `input_schema` で後方互換維持) |

## Discovered Issue (Fixed)

**`_llm_call_count` ステートキー衝突**: AgentTool は親のセッションステートを子にコピーする際、`_adk` プレフィックスのキーのみ除外する。従来の `_llm_call_count` は除外されず、親のカウント値が子に漏れ、sub-agent が即座にリミット超過で停止する問題があった。キーを `_adk_llm_call_count` にリネームすることで解消。

## Test plan

- [x] `uv run ruff check src/` — Lint pass
- [x] `uv run ruff format --check src/` — Format pass
- [x] `uv run pytest` — 20 tests pass
- [x] Import check: `from analyzer.agents.adk_agents import create_agentic_search_agent` OK
- [ ] Manual E2E test: Agentic search mode で investigate_document が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)