### PR TITLE
fix: 公開トグルUIの改善とCORS PATCHメソッド追加

### DIFF
--- a/backend/src/analyzer/main.py
+++ b/backend/src/analyzer/main.py
@@ -85,7 +85,7 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=[
             "Authorization",
             "Content-Type",

--- a/frontend/src/app/qa/page.tsx
+++ b/frontend/src/app/qa/page.tsx
@@ -849,23 +849,17 @@ export default function QAPage() {
                           <>
                             <button
                               onClick={() => handlePublish(message.id, message.reportId!, !message.isPublic)}
-                              className="inline-flex items-center gap-2 text-sm text-gray-600"
-                              title={message.isPublic ? "Click to make private" : "Click to share with all users"}
+                              className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors
+                                       focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                              style={{ backgroundColor: message.isPublic ? "#22c55e" : "#d1d5db" }}
+                              role="switch"
+                              aria-checked={!!message.isPublic}
+                              aria-label={message.isPublic ? "Public: click to make private" : "Private: click to share with all users"}
                             >
                               <span
-                                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                                  message.isPublic ? "bg-green-500" : "bg-gray-300"
-                                }`}
-                              >
-                                <span
-                                  className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                                    message.isPublic ? "translate-x-4.5" : "translate-x-0.5"
-                                  }`}
-                                />
-                              </span>
-                              <span className={message.isPublic ? "text-green-700 font-medium" : "text-gray-500"}>
-                                {message.isPublic ? "Public" : "Private"}
-                              </span>
+                                className="inline-block h-4 w-4 rounded-full bg-white shadow transition-transform"
+                                style={{ transform: message.isPublic ? "translateX(1.375rem)" : "translateX(0.25rem)" }}
+                              />
                             </button>
                             <button
                               onClick={() => handleDeleteReport(message.id, message.reportId!)}


### PR DESCRIPTION
## Summary
- 公開トグルスイッチからテキストラベル（Public/Private）を削除し、色と位置のみで状態表現するシンプルなデザインに変更
- CORSの`allow_methods`に`PATCH`を追加（Publish APIがブラウザから呼べない原因）

## Changes
- `frontend/src/app/qa/page.tsx`: トグルUIをシンプル化、`role=switch`/`aria`属性追加
- `backend/src/analyzer/main.py`: CORS `allow_methods`に`PATCH`追加

## Test plan
- [ ] トグルが画像のOKパターン（ラベルなし、色と位置で状態表現）に一致すること
- [ ] Publishトグル操作で「Failed to fetch」エラーが解消されること
- [ ] PATCH `/qa/reports/{id}/publish` がブラウザから正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)