### PR TITLE
fix: Vertex AI 429 RESOURCE_EXHAUSTED リトライ対策

### DIFF
--- a/backend/src/analyzer/providers/firestore_provider.py
+++ b/backend/src/analyzer/providers/firestore_provider.py
@@ -40,6 +40,15 @@ class FirestoreEvidenceProvider(EvidenceProvider):
             vertexai=True,
             project=project_id,
             location=location,
+            http_options=genai.types.HttpOptions(
+                retry_options=genai.types.HttpRetryOptions(
+                    attempts=3,
+                    initial_delay=1.0,
+                    max_delay=30.0,
+                    exp_base=2.0,
+                    http_status_codes=[429, 503],
+                ),
+            ),
         )
 
     async def _get_query_embedding(self, query: str) -> list[float]:


### PR DESCRIPTION
## Summary
- ADK の `Gemini.retry_options` を有効化し、429/503 エラー時に指数バックオフ（2s→4s→8s→16s、最大5回）で自動リトライ
- リトライが尽きた場合の `on_model_error_callback` を追加し、クラッシュではなく「レート制限に達しました」とグレースフルに終了
- エンベディング用 `genai.Client` にもリトライ設定を追加（最大3回）

## Test plan
- [ ] ローカルで Agentic Search を実行し、正常に回答が返ることを確認
- [ ] Cloud Run デプロイ後に429エラーが減少していることをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)