### PR TITLE
feat: Agentic SearchのAI思考プロセスを可視化

### DIFF
--- a/backend/src/analyzer/agents/adk_agents.py
+++ b/backend/src/analyzer/agents/adk_agents.py
@@ -10,6 +10,7 @@ from google.adk.agents import LlmAgent
 from google.adk.agents.context_cache_config import ContextCacheConfig
 from google.adk.apps.app import App
 from google.adk.models.google_llm import Gemini
+from google.adk.planners import BuiltInPlanner
 from google.adk.runners import Runner
 from google.adk.tools.agent_tool import AgentTool
 from google.genai import types as genai_types
@@ -255,6 +256,7 @@ def create_agentic_search_agent(
     meeting_id: str,
     model: str = "gemini-3-pro-preview",
     language: str = "ja",
+    enable_thinking: bool = False,
 ) -> LlmAgent:
     """
     Create an agentic search agent for multi-step document investigation.
@@ -444,11 +446,21 @@ valuable. Avoid being overly brief.
     )
     investigation_tool = AgentTool(agent=investigation_agent, skip_summarization=False)
 
+    planner = None
+    if enable_thinking:
+        planner = BuiltInPlanner(
+            thinking_config=genai_types.ThinkingConfig(
+                include_thoughts=True,
+                thinking_budget=2048,
+            )
+        )
+
     return LlmAgent(
         model=_create_gemini_model(model),
         name="agentic_search_agent",
         description="Agentic search agent for multi-step document investigation",
         instruction=instruction,
+        planner=planner,
         tools=[
             list_meeting_documents_enhanced,
             search_evidence,
@@ -770,9 +782,12 @@ class ADKAgentRunner:
                 session_id=session_id,
                 new_message=user_message,
             ):
-                # Detect function call events (tool invocations)
+                # Detect thinking, function call, and function response events
                 if event.content and event.content.parts:
                     for part in event.content.parts:
+                        # Yield model thinking/reasoning (BuiltInPlanner thoughts)
+                        if getattr(part, "thought", False) and part.text:
+                            yield {"type": "thinking", "content": part.text}
                         if hasattr(part, "function_call") and part.function_call:
                             fc = part.function_call
                             # Summarize args to avoid flooding the stream

--- a/backend/src/analyzer/api/qa.py
+++ b/backend/src/analyzer/api/qa.py
@@ -120,6 +120,7 @@ async def ask_question_stream(
     language: str = Query("ja", pattern="^(ja|en)$", description="Response language"),
     session_id: str | None = Query(None, description="Session ID for conversation continuity"),
     mode: str = Query("rag", pattern="^(rag|agentic)$", description="Q&A mode"),
+    show_thinking: bool = Query(False, description="Show AI thinking process (agentic mode)"),
 ):
     """
     Answer a question with streaming response (SSE).
@@ -167,6 +168,7 @@ async def ask_question_stream(
                 user_id=current_user.uid,
                 session_id=session_id,
                 mode=qa_mode,
+                enable_thinking=show_thinking,
             ):
                 if event.type == "chunk":
                     yield {
@@ -182,6 +184,11 @@ async def ask_question_stream(
                     yield {
                         "event": "tool_result",
                         "data": event.content or "{}",
+                    }
+                elif event.type == "thinking":
+                    yield {
+                        "event": "thinking",
+                        "data": json.dumps({"content": event.content}),
                     }
                 elif event.type == "evidence":
                     yield {

--- a/backend/src/analyzer/services/qa_service.py
+++ b/backend/src/analyzer/services/qa_service.py
@@ -221,6 +221,7 @@ class QAService:
         user_id: str | None = None,
         session_id: str | None = None,
         mode: QAMode = QAMode.RAG,
+        enable_thinking: bool = False,
     ) -> AsyncGenerator[QAStreamEvent, None]:
         """
         Answer a question with streaming response.
@@ -289,6 +290,7 @@ class QAService:
                 meeting_id=effective_scope_id,
                 model=self.model,
                 language=language,
+                enable_thinking=enable_thinking,
             )
             agent_context = AgentToolContext(
                 evidence_provider=self.evidence_provider,
@@ -352,6 +354,11 @@ class QAService:
                                 "summary": event.get("summary", ""),
                             }
                         ),
+                    )
+                elif event["type"] == "thinking":
+                    yield QAStreamEvent(
+                        type="thinking",
+                        content=event.get("content", ""),
                     )
                 elif event["type"] == "done":
                     full_answer = event.get("content", full_answer)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -559,6 +559,7 @@ export async function createQAStream(
   language: AnalysisLanguage = "ja",
   sessionId?: string,
   mode: QAMode = "rag",
+  showThinking: boolean = false,
 ): Promise<EventSource> {
   const token = await getAuthToken();
   if (!token) {
@@ -581,6 +582,10 @@ export async function createQAStream(
 
   if (sessionId) {
     params.set("session_id", sessionId);
+  }
+
+  if (showThinking) {
+    params.set("show_thinking", "true");
   }
 
   const url = `${API_BASE}/qa/stream?${params.toString()}`;


### PR DESCRIPTION
## Summary
- ADKの`BuiltInPlanner` + Geminiの`ThinkingConfig`を活用し、Agentic Search実行中のAIの内部思考（推論プロセス）をQA画面にリアルタイム表示
- モデルがツール選択前に行う判断（なぜそのツールを呼ぶか、次に何をすべきか）が💭アイコン付きで表示される
- 既存のSSEストリーミング基盤に`thinking`イベントタイプを追加する形で実装

## Changes
| File | Description |
|------|-------------|
| `backend/src/analyzer/agents/adk_agents.py` | `BuiltInPlanner(ThinkingConfig(include_thoughts=True))` 追加 + `run_stream()`で`part.thought`検出・yield |
| `backend/src/analyzer/services/qa_service.py` | `thinking`イベント中継 |
| `backend/src/analyzer/api/qa.py` | `thinking` SSEイベント送信 |
| `frontend/src/app/qa/page.tsx` | `thinking`イベント受信・💭斜体テキスト表示 |

## Test plan
- [ ] QA画面でAgentic Searchを実行し、investigation stepsに💭思考テキストが表示されることを確認
- [ ] ツール呼び出し表示（🔍/→）が従来通り動作することを確認
- [ ] RAGモードでは思考イベントが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)