### PR TITLE
feat: 添付ファイルをQAセッションスコープに変更

### DIFF
--- a/backend/src/analyzer/agents/adk_agents.py
+++ b/backend/src/analyzer/agents/adk_agents.py
@@ -682,7 +682,19 @@ class ADKAgentRunner:
         Returns:
             The session_id (same as input).
         """
-        await cleanup_expired_sessions()
+        expired_session_ids = await cleanup_expired_sessions()
+        if expired_session_ids and self.agent_context.attachment_service:
+            for expired_id in expired_session_ids:
+                try:
+                    count = await self.agent_context.attachment_service.delete_by_session(
+                        expired_id
+                    )
+                    if count:
+                        logger.info(
+                            f"Cleaned up {count} attachments for expired session {expired_id}"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to clean up attachments for session {expired_id}: {e}")
 
         existing_session = await self.session_service.get_session(
             app_name=APP_NAME,

--- a/backend/src/analyzer/agents/context.py
+++ b/backend/src/analyzer/agents/context.py
@@ -74,6 +74,9 @@ class AgentToolContext:
     # Meeting ID for meeting-scoped agents
     meeting_id: str | None = None
 
+    # Session ID for session-scoped attachment filtering
+    session_id: str | None = None
+
     def reset_evidences(self) -> None:
         """Reset used evidences for a new run."""
         self.used_evidences = []

--- a/backend/src/analyzer/agents/session_manager.py
+++ b/backend/src/analyzer/agents/session_manager.py
@@ -68,12 +68,12 @@ def touch_session(session_id: str) -> None:
         _session_timestamps[session_id] = datetime.now(UTC)
 
 
-async def cleanup_expired_sessions() -> int:
+async def cleanup_expired_sessions() -> list[str]:
     """
     Remove sessions that have exceeded the TTL.
 
     Returns:
-        Number of sessions cleaned up.
+        List of expired session IDs that were cleaned up.
     """
     global _last_cleanup
 
@@ -81,7 +81,7 @@ async def cleanup_expired_sessions() -> int:
 
     # Skip if cleanup was done recently
     if _last_cleanup and now - _last_cleanup < CLEANUP_INTERVAL:
-        return 0
+        return []
 
     _last_cleanup = now
     expired_sessions = []
@@ -100,7 +100,7 @@ async def cleanup_expired_sessions() -> int:
             # The memory will be reclaimed when the service is reset or
             # when we implement a custom session service with proper deletion.
 
-    return len(expired_sessions)
+    return expired_sessions
 
 
 def get_active_session_count() -> int:

--- a/backend/src/analyzer/agents/tools/adk_agentic_tools.py
+++ b/backend/src/analyzer/agents/tools/adk_agentic_tools.py
@@ -125,7 +125,9 @@ async def list_meeting_attachments(
     logger.info(f"Listing attachments for meeting: {meeting_id}")
 
     try:
-        attachments = await ctx.attachment_service.list_by_meeting(meeting_id)
+        attachments = await ctx.attachment_service.list_by_meeting(
+            meeting_id, session_id=ctx.session_id
+        )
         results = [
             {
                 "attachment_id": a.id,

--- a/backend/src/analyzer/models/attachment.py
+++ b/backend/src/analyzer/models/attachment.py
@@ -20,6 +20,7 @@ class Attachment(BaseModel):
     file_size_bytes: int = Field(..., description="File size in bytes")
     uploaded_by: str = Field(..., description="User ID who uploaded the file")
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    session_id: str | None = Field(None, description="QA session ID this attachment belongs to")
 
     def to_firestore(self) -> dict[str, Any]:
         """Convert to Firestore-compatible dictionary."""

--- a/backend/src/analyzer/services/qa_service.py
+++ b/backend/src/analyzer/services/qa_service.py
@@ -161,6 +161,7 @@ class QAService:
                 storage=self.storage,
                 attachment_service=self.attachment_service,
                 meeting_id=effective_scope_id,
+                session_id=session_id,
             )
         else:
             agent_scope = "global" if multi_meeting_mode else scope.value
@@ -303,6 +304,7 @@ class QAService:
                 storage=self.storage,
                 attachment_service=self.attachment_service,
                 meeting_id=effective_scope_id,
+                session_id=session_id,
             )
         else:
             agent_scope = "global" if multi_meeting_mode else scope.value

--- a/frontend/src/app/qa/page.tsx
+++ b/frontend/src/app/qa/page.tsx
@@ -180,16 +180,16 @@ export default function QAPage() {
     scrollToBottom();
   }, [messages]);
 
-  // Load attachments when meeting changes in agentic mode
+  // Load attachments when meeting or session changes in agentic mode
   useEffect(() => {
     if (mode === "agentic" && scopeIds.length === 1) {
-      listAttachments(scopeIds[0])
+      listAttachments(scopeIds[0], sessionId)
         .then(setAttachments)
         .catch(() => setAttachments([]));
     } else {
       setAttachments([]);
     }
-  }, [mode, scopeIds]);
+  }, [mode, scopeIds, sessionId]);
 
   const toggleEvidences = (messageId: string) => {
     setExpandedEvidences((prev) => ({
@@ -235,7 +235,7 @@ export default function QAPage() {
     if (!file || scopeIds.length !== 1) return;
     setIsUploading(true);
     try {
-      const attachment = await uploadAttachment(scopeIds[0], file);
+      const attachment = await uploadAttachment(scopeIds[0], file, sessionId);
       setAttachments((prev) => [attachment, ...prev]);
       toast.success(`Uploaded: ${file.name}`);
     } catch {
@@ -572,6 +572,7 @@ export default function QAPage() {
 
   const clearChat = () => {
     setMessages([]);
+    setAttachments([]);
     setSessionId(generateSessionId());
   };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -652,12 +652,16 @@ export async function deleteQAReport(reportId: string): Promise<void> {
 export async function uploadAttachment(
   meetingId: string,
   file: File,
+  sessionId?: string,
 ): Promise<Attachment> {
   const token = await getAuthToken();
   if (!token) throw new Error("Authentication required");
 
   const formData = new FormData();
   formData.append("file", file);
+  if (sessionId) {
+    formData.append("session_id", sessionId);
+  }
 
   const response = await fetch(
     `${API_BASE}/meetings/${encodeURIComponent(meetingId)}/attachments`,
@@ -676,9 +680,15 @@ export async function uploadAttachment(
 
 export async function listAttachments(
   meetingId: string,
+  sessionId?: string,
 ): Promise<Attachment[]> {
+  const params = new URLSearchParams();
+  if (sessionId) {
+    params.set("session_id", sessionId);
+  }
+  const query = params.toString() ? `?${params.toString()}` : "";
   return fetchApi<Attachment[]>(
-    `/meetings/${encodeURIComponent(meetingId)}/attachments`,
+    `/meetings/${encodeURIComponent(meetingId)}/attachments${query}`,
   );
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -331,6 +331,7 @@ export interface Attachment {
   file_size_bytes: number;
   uploaded_by: string;
   created_at: string;
+  session_id?: string;
 }
 
 // Meeting Summary Types (P3-02)


### PR DESCRIPTION
## Summary
- 添付ファイルに`session_id`を紐づけ、QAセッションのライフサイクルに合わせて自動クリーンアップされるように変更
- セキュリティレビューで検出された、添付ファイルがFirestore/GCSに永続保存されセッション終了後もアクセス可能な問題を解消
- セッション期限切れ（1時間TTL）時に、該当セッションの添付ファイルをFirestore/GCSから自動削除

## Changes

### Backend (8 files)
- `models/attachment.py`: `session_id`フィールド追加（後方互換: 既存データは`None`）
- `services/attachment_service.py`: `upload()`/`list_by_meeting()`にsession_id対応、`delete_by_session()`新規追加
- `api/attachments.py`: upload(Form)/list(Query)に`session_id`パラメータ追加
- `agents/session_manager.py`: `cleanup_expired_sessions()`の戻り値を`int`→`list[str]`に変更
- `agents/adk_agents.py`: `_ensure_session()`で期限切れセッションの添付を自動削除
- `agents/context.py`: `AgentToolContext`に`session_id`フィールド追加
- `agents/tools/adk_agentic_tools.py`: `list_meeting_attachments`でsession_idフィルタ適用
- `services/qa_service.py`: `AgentToolContext`構築時に`session_id`を渡す

### Frontend (3 files)
- `lib/types.ts`: `Attachment`に`session_id?`追加
- `lib/api.ts`: `uploadAttachment()`/`listAttachments()`に`sessionId`引数追加
- `app/qa/page.tsx`: 既存の`sessionId`をupload/listに渡す、clearChatで添付リセット

## Test plan
- [x] `uv run ruff check src/` — パス
- [x] `uv run ruff format --check src/` — パス
- [x] `uv run pytest` — 20 passed
- [x] `npm run lint` — パス
- [x] `npm run build` — パス
- [ ] QAページでファイルアップロード → 添付一覧に表示される
- [ ] 「チャットクリア」→ 添付一覧がリセットされる
- [ ] 別タブで同じミーティングを開く → 他タブの添付は見えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)